### PR TITLE
added support for source_content_type in os_daemon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ timeout = 60000
 ; Ignore the following databases (again comma separated list)
 ; Regular expressions are again allowed:
 blacklist = /^_/
+; Only attachments which match any of the mime types below are processed (separate with comma).
+; Default is /^image\// Regular expressions are allowed:
+;source_content_types = /^image\//,application/postscript
 ```
 
 ## Imagemagick Configuration

--- a/lib/couchmagick-stream.js
+++ b/lib/couchmagick-stream.js
@@ -11,12 +11,33 @@ var nano = require('nano');
 var strformat = require('strformat');
 var docuri = require('docuri');
 
+function compileRegexp(string) {
+  if (string instanceof RegExp) {
+    return string;
+  }
+  if (string.match(/^\/.*\/$/)) {
+    string = string.slice(1, string.length - 1);
+  } else {
+    string = '^' + string + '$';
+  }
+  return new RegExp(string);
+}
+
 
 // TODO: emit all documents, also filtered one, to enable checkpointing
 module.exports = function couchmagick(url, options) {
   options = options || {};
   options.concurrency = options.concurrency || 1;
   options.timeout = options.timeout || 60 * 1000; // 1 minute
+
+  options.source_content_types = options.source_content_types ?
+          options.source_content_types.split(/,\s*/) : [/^image\//];
+  if (options.source_content_types) {
+    if (!Array.isArray(options.source_content_types)) {
+      options.source_content_types = [options.source_content_types];
+    }
+    options.source_content_types = options.source_content_types.map(compileRegexp);
+  }
 
 
   var couch = nano(url);
@@ -224,7 +245,10 @@ module.exports = function couchmagick(url, options) {
         return false;
       }
 
-      return data.doc._attachments[data.name].content_type.match(/^image\//);
+      var content_type = data.doc._attachments[data.name].content_type;
+      return options.source_content_types.some(function(r) {
+              return content_type.match(r);
+      });
     }),
 
     // split stream into versions


### PR DESCRIPTION
Hi,

thank you a lot for this powerfull and well designed module. We will use it in several cms projects.

I added a new couch config property (local.ini) to allow image magick convert to occur not only for attachments with a mime type matching image/\* but for any mime type supported by convert.

E.g. setting `source_content_types = /^image\//,application/postscript` will enable thumbnail generation for eps files. Even thumbnails for pdf or video files could be generated.

As I implemented fallback to a default value, compatibilty of existing configurations won't be broken by the new version

Please integrate this patch into your master branch and publish it to npm.

Sincerly,

Felix
